### PR TITLE
Add script to register a service account without downloading a json keyfile

### DIFF
--- a/scripts/register_service_account/README.md
+++ b/scripts/register_service_account/README.md
@@ -10,3 +10,39 @@ Usage (from the main directory):
 Usage (using Docker):
 
 ```docker run --rm -it -v "$HOME"/.config:/.config -v <path to your service account credentials json file>:/svc.json broadinstitute/firecloud-tools python /scripts/register_service_account/register_service_account.py -j /svc.json -e <email address for owner of this service account, it's where notifications will go>```
+
+## Register a service account for use in FireCloud without a JSON credentials keyfile
+Some organizations don't allow downloads of json keyfiles. In this case, it is still possible to run a VM with the credentials of a service account, and then use those credentials to make the request. You will need to run the modified version of the script in order to do this.
+1. Create a VM with the service account's identity
+    1. Navigate to the Create new Instance page in GCP for the project containing the service account
+    2. Choose anything for name, size, and region. 
+    3. Most importantly **be sure that the service account** is selected in the Identity and API access section
+    4. We also need to enable the email, profile, and openid scopes to the service account. Unfortunately the UI doesn't allow us to add scopes for these kinds of service accounts. However if we create the VM through a gcloud command, we can add the scopes. **Do not click create**, instead click on "Equivalent Command Line" and copy the command.    
+    5.  Edit the command to add the email, profile and openid scope. Run this command. For example, my command looks like:
+```
+gcloud compute instances create instance-1 \
+  --project=terra-foo-foo-dev \
+  --zone=us-central1-a \
+  --machine-type=e2-medium \
+  --network-interface=network-tier=PREMIUM,subnet=default \
+  --maintenance-policy=MIGRATE \
+  --provisioning-model=STANDARD \
+  --service-account=foo-example-sa@terra-foo-foo-dev.iam.gserviceaccount.com \
+  --scopes=https://www.googleapis.com/auth/cloud-platform,email,profile,openid \
+  --create-disk=auto-delete=yes,boot=yes,device-name=instance-1,image=projects/debian-cloud/global/images/debian-11-bullseye-v20220920,mode=rw,size=10,type=projects/terra-foo-foo-dev/zones/us-central1-a/diskTypes/pd-balanced \
+  --no-shielded-secure-boot \
+  --shielded-vtpm \
+  --shielded-integrity-monitoring \
+  --reservation-affinity=any
+```
+2. SSH to the VM and run the Python script
+Once the above VM is created and running, you can SSH to it. API requests made while in this VM will be made with the service account's credentials. 
+    1. SSH to the VM
+    2. The Python script requires a few libraries to be installed via pip. Pip isn't installed by default, so install pip via `sudo apt-get install python3-pip`
+    3. Install google-auth, urllib3 and firecloud via `pip3 install google-auth urllib3 firecloud`
+    4. Run the `register_service_account_no_keyfile.py` script
+    ```
+    python3 register_service_account_no_keyfile.py --owner_email=my_email@domain.com --first_name=Foo --last_name=Sa
+    ```
+    5.  If it worked, the script should output something like
+```The service account foo-example-sa@terra-foo-foo-dev.iam.gserviceaccount.com is now registered with FireCloud. You can share workspaces with this address, or use it to call APIs.```

--- a/scripts/register_service_account/register_service_account_no_keyfile.py
+++ b/scripts/register_service_account/register_service_account_no_keyfile.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# This version is modified from the original register_service_account.py.
+# The intent is that you run this script AS the service account,
+# therefore bypassing the need for a json keyfile
+
+from argparse import ArgumentParser
+from google.auth.transport.requests import AuthorizedSession
+import firecloud.api as fapi
+import google.auth
+import json
+
+def main():
+    # The main argument parser
+    parser = ArgumentParser(description="Register a service account for use in FireCloud.")
+
+    # Core application arguments
+    parser.add_argument('-e', '--owner_email', dest='owner_email', action='store', required=True, help='Email address of the person who owns this service account')
+    parser.add_argument('-u', '--url', dest='fc_url', action='store', default="https://api.firecloud.org", required=False, help='Base url of FireCloud server to contact (Default Prod URL: "https://api.firecloud.org", Dev URL: "https://firecloud-orchestration.dsde-dev.broadinstitute.org")')
+
+    # Additional arguments
+    parser.add_argument('-f', '--first_name', dest='first_name', action='store', default="None", required=False, help='First name to register for user')
+    parser.add_argument('-l', '--last_name', dest='last_name', action='store', default="None", required=False, help='Last name to register for user')
+
+    args = parser.parse_args()
+
+    scopes = ['https://www.googleapis.com/auth/userinfo.profile', 'https://www.googleapis.com/auth/userinfo.email']
+    credentials, project = google.auth.default(scopes=scopes)
+    authed_session = AuthorizedSession(credentials)
+
+    headers = {
+        "User-Agent": fapi.FISS_USER_AGENT,
+        "Content-Type": "application/json",
+    }
+
+    uri = args.fc_url + "/register/profile"
+
+    profile_json = {"firstName": args.first_name,
+                    "lastName": args.last_name,
+                    "title": "None",
+                    "contactEmail": args.owner_email,
+                    "institute": "None",
+                    "institutionalProgram": "None",
+                    "programLocationCity": "None",
+                    "programLocationState": "None",
+                    "programLocationCountry": "None",
+                    "pi": "None",
+                    "nonProfitStatus": "false"}
+    response = authed_session.request('POST', uri, headers=headers, data=json.dumps(profile_json))
+
+    if response.status_code == 200:
+        print("The service account %s is now registered with FireCloud. You can share workspaces with this address, or use it to call APIs." % credentials.service_account_email)
+    else:
+        print("Unable to register service account: %s" % response.text)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is copied almost nearly verbatim from https://github.com/broadinstitute/firecloud-tools/pull/44

Some organizations don't allow downloads of json keyfiles. In this case, it is still possible to run a VM with the credentials of a service account, and then use those credentials to make the request. 

This PR:
1) Adds instructions for how to ssh to a VM with the proper scope and service account credentials
2) Adds a script that one can run on the above VM to register the service account to Terra without needing the json credentials keyfile